### PR TITLE
Setup gh-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "gh-pages": "^4.0.0"
+  }
+}


### PR DESCRIPTION
Install the gh-pages package in our project. 
The package allows us to publish build files into a gh-pages branch on Github, where they can be hosted. 